### PR TITLE
fix syntax ecosystems.config.json

### DIFF
--- a/ecosystems.config.json
+++ b/ecosystems.config.json
@@ -30,7 +30,7 @@
 
       "watch": false,
 
-      "node_args": ["max-old-space-size=4096"],
+      "node_args": ["--max-old-space-size=4096"],
 
       "env": {
         "NODE_ENV": "production"


### PR DESCRIPTION
fix syntax
node_args": ["max-old-space-size=4096"] -> node_args": ["--max-old-space-size=4096"]